### PR TITLE
Fixed-fortune-cards-layout

### DIFF
--- a/src/styles/pages/activities/FortuneCard.css
+++ b/src/styles/pages/activities/FortuneCard.css
@@ -1,6 +1,7 @@
 .FortuneCard {
   text-align: center;
-  margin: 20px;
+  margin: 20px auto;
+  max-width: 100%;
 }
 
 h1 {
@@ -24,6 +25,8 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  gap: 20px;
+  width: 100%;
 }
 
 .card {
@@ -33,10 +36,13 @@ h1 {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 20px;
   margin: 10px;
-  max-width: 300px;
   text-align: center;
   transition: transform 0.2s ease-in-out;
+  flex: 1 1 280px;   
+  min-width: 260px;  
+  max-width: 320px;  
 }
+
 
 .card:hover {
   transform: scale(1.05);


### PR DESCRIPTION
I fixed the layout of fortune cards, following are the changes made:
1) The cards align side by side for better visibility.
2) Width of each card has been made to fit the content to avoid line or word breakages.




<img width="1546" height="936" alt="image" src="https://github.com/user-attachments/assets/3b99c791-5729-47c7-b8c5-258b8480d9a9" />
